### PR TITLE
Add support for cython, depend on sagemath, instructions for PyPI

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -4,6 +4,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 set -e
+$HOME/SageMath/sage -pip install --upgrade --no-index -v sagemath # Check that Sage is installed
 $HOME/SageMath/sage -pip install --upgrade --no-index -v .
 $HOME/SageMath/sage setup.py test
 (cd docs && $HOME/SageMath/sage -sh -c "make html")

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@
 language: python
 matrix:
   include:
-  - env: CACHE_NAME=7.6 DEPLOY_DOC_FROM_BRANCH=master DEPLOY_DOC_TO_DIRECTORY=/ SAGE_SERVER=http://mirrors.xmission.com/sage/ SAGE_IMAGE=linux/64bit/sage-7.6-Ubuntu_12.04-x86_64.tar.bz2
+  - env: CACHE_NAME=7.6 DEPLOY_DOC_FROM_BRANCH=master DEPLOY_DOC_TO_REPOSITORY=username/sample_sage
+     DEPLOY_DOC_TO_DIRECTORY=doc/html SAGE_SERVER=http://mirrors.xmission.com/sage/ SAGE_IMAGE=linux/64bit/sage-7.6-Ubuntu_12.04-x86_64.tar.bz2
+  allow_failures:
   - env: CACHE_NAME=7.5.1 SAGE_SERVER=http://mirrors.xmission.com/sage/ SAGE_IMAGE=linux/64bit/sage-7.5.1-Ubuntu_12.04-x86_64.tar.bz2
 install:
 - ./.travis-install.sh

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Setup
 ------
 
 All packaging setup is done through ``setup.py``. To create your own package
-follow the strcuture of the file and change the parameters accordingly.
+follow the structure of the file and change the parameters accordingly.
 
 Source code
 -----------
@@ -120,14 +120,14 @@ versions used.
 Automatically deploying documentation to GitHub pages using Travis CI
 ---------------------------------------------------------------------
 
- * First do the steps described above to enable Travis CI integration
-   of your GitHub-hosted project.
-   
- * If you don't already have GitHub pages for your project: Create and
-   checkout a branch ``gh-pages`` in your repository and put an empty
-   file ``.nojekyll`` in it.  (See
-   https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/)::
-   Commit it and push it to GitHub::
+* First do the steps described above to enable Travis CI integration
+  of your GitHub-hosted project.
+
+* If you don't already have GitHub pages for your project: Create and
+  checkout a branch ``gh-pages`` in your repository and put an empty
+  file ``.nojekyll`` in it.  (See
+  https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/)::
+  Commit it and push it to GitHub::
 
     $ git clone --single-branch --depth 1 https://github.com/USER/PROJECT.git gh-pages
     $ cd gh-pages
@@ -138,38 +138,38 @@ Automatically deploying documentation to GitHub pages using Travis CI
     $ git commit -m "Initial commit"
     $ git push -u origin gh-pages
     $ cd ..
-    
- * (Back in your working copy:) Generate a new ssh key pair with an
-   empty passphrase::
+
+* (Back in your working copy:) Generate a new ssh key pair with an
+  empty passphrase::
 
     $ ssh-keygen -t dsa -f .travis_ci_gh_pages_deploy_key
 
- * Add the public ssh key (contents of the file
-   ``.travis_ci_gh_pages_deploy_key.pub``) to your GitHub repository
-   as a deploy key (Settings/Deploy keys/Add deploy key).
-   Title: Key for deploying documentation to GitHub pages.
-   Check Allow write access.
+* Add the public ssh key (contents of the file
+  ``.travis_ci_gh_pages_deploy_key.pub``) to your GitHub repository
+  as a deploy key (Settings/Deploy keys/Add deploy key).
+  Title: Key for deploying documentation to GitHub pages.
+  Check Allow write access.
 
- * Install the Travis CI command-line client from
-   https://github.com/travis-ci/travis.rb::
+* Install the Travis CI command-line client from
+  https://github.com/travis-ci/travis.rb::
 
     $ gem install travis
-   
- * Log in to Travis CI using your GitHub credentials::
+
+* Log in to Travis CI using your GitHub credentials::
 
     $ travis login
-   
- * Encrypt the private ssh key, add the decryption keys
-   as secure environment variables to Travis CI, and
-   add code to ``.travis.yml`` to decrypt it::
+
+* Encrypt the private ssh key, add the decryption keys
+  as secure environment variables to Travis CI, and
+  add code to ``.travis.yml`` to decrypt it::
 
     $ travis encrypt-file .travis_ci_gh_pages_deploy_key --add before_script
 
- * Add the encrypted private ssh key to the repository::
+* Add the encrypted private ssh key to the repository::
 
     $ git add .travis_ci_gh_pages_deploy_key.enc
 
- * Have git ignore the other keys (and the gh-pages directory)::
+* Have git ignore the other keys (and the gh-pages directory)::
 
     $ echo >> .gitignore
     $ echo "/.travis_ci_gh_pages_deploy_key" >> .gitignore
@@ -177,19 +177,19 @@ Automatically deploying documentation to GitHub pages using Travis CI
     $ echo "/gh-pages" >> .gitignore
     $ git add .gitignore
 
- * Optionally, edit ``.travis.yml`` to adjust variables ``DEPLOY_DOC_...``
+* Optionally, edit ``.travis.yml`` to adjust variables ``DEPLOY_DOC_...``
 
- * Commit all changes to GitHub.  The Travis CI build should then run
-   automatically and deploy it::
+* Commit all changes to GitHub.  The Travis CI build should then run
+  automatically and deploy it::
 
     $ git add .travis.yml
     $ git commit -m "Deploy built documentation to GitHub"
     $ git push
- 
- * The deployed documentation will be available at:
-   https://USER.github.io/PROJECT/
-   This can be customized by changing ``DEPLOY_DOC_TO_DIRECTORY=/``
-   to another directory in ``.travis.yml``
-   For example, setting ``DEPLOY_DOC_TO_DIRECTORY=doc/html`` will make
-   the deployed documentation available at:
-   https://USER.github.io/PROJECT/doc/html/
+
+* The deployed documentation will be available at:
+  https://USER.github.io/PROJECT/
+  This can be customized by changing ``DEPLOY_DOC_TO_DIRECTORY=/``
+  to another directory in ``.travis.yml``
+  For example, setting ``DEPLOY_DOC_TO_DIRECTORY=doc/html`` will make
+  the deployed documentation available at:
+  https://USER.github.io/PROJECT/doc/html/

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,22 @@ shorthand:
 Install from PyPI
 ^^^^^^^^^^^^^^^^^^
 
-TODO: distribute on PyPI.
+Here are the main steps to follow in order to make the package available to the PyPI repository::
+
+* Create an account at https://pypi.python.org/pypi
+* Install ``twine`` in Sage::
+
+    $ sage -pip install --upgrade twine'
+
+* Create the distribution::
+
+    $ python setup.py sdist
+
+ (you can also use ``bdist`` instead to create the built distribution)
+
+* Upload to PyPI::
+
+    $ twine upload dist/* -r pypi
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -32,20 +32,19 @@ shorthand:
 Install from PyPI
 ^^^^^^^^^^^^^^^^^^
 
-Here are the main steps to follow in order to make the package available to the PyPI repository::
+Create an account at https://pypi.python.org/pypi
 
-* Create an account at https://pypi.python.org/pypi
-* Install ``twine`` in Sage::
+Install ``twine`` in Sage::
 
     $ sage -pip install --upgrade twine'
 
-* Create the distribution::
+Create the distribution::
 
     $ python setup.py sdist
 
  (you can also use ``bdist`` instead to create the built distribution)
 
-* Upload to PyPI::
+Upload to PyPI::
 
     $ twine upload dist/* -r pypi
 

--- a/sage_sample/ultimate_question.py
+++ b/sage_sample/ultimate_question.py
@@ -23,6 +23,7 @@ AUTHORS:
 - Viviane Pons: initial implementation
 """
 from sage.combinat.combinat import catalan_number
+from one_cython_file import quick_question
 
 def answer_to_ultimate_question():
     r"""
@@ -42,4 +43,4 @@ def answer_to_ultimate_question():
         sage: answer_to_ultimate_question() == 42
         True
     """
-    return catalan_number(5)
+    return quick_question(catalan_number(5)) - 1


### PR DESCRIPTION
After using the template to distribute my own project, I have added some functionality to the package. In particular:

1. Added a cython file and the necessary changes to make it work.
2. This being a Sage package, it depends on the python package `sagemath`. This is a tiny python package available at PyPI that allows to check which version of Sage is installed.
3. Added some basic instructions to distribute the code to PyPI.